### PR TITLE
Uses v1.12 of the forgerock-eidas-psd2-cert-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.forgerock</groupId>
             <artifactId>forgerock-eidas-psd2-cert-sdk</artifactId>
-            <version>1.5-SNAPSHOT</version>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <eidas.psd2.sdk.version>1.7</eidas.psd2.sdk.version>
+        <eidas.psd2.sdk.version>1.12</eidas.psd2.sdk.version>
 
         <jwt.nimbus.version>7.3</jwt.nimbus.version>
     </properties>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.forgerock</groupId>
             <artifactId>forgerock-eidas-psd2-cert-sdk</artifactId>
-            <version>1.12</version>
+	    <version>${eidas.psd2.sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>


### PR DESCRIPTION
Update the auth node to use the latest version (1.12 of the eidas cert sdk). This SDK fixes an issue around how the SDK created and parsed the qcType QCStatements in the cert. The library will now work with both Open Banking Ltd issued test Eidas PSD2 certs, ForgeRock Open Banking certs (generated by v1.12 of the cert sdk) and the one test cert we have obtained that was generated by a cert authority (D-Trust).